### PR TITLE
Fix CLI mode argument handling

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11,6 +11,10 @@ async def connect(bot, device_id, channel_id):
 
         stream = sound.PCMStream()
         channel = bot.get_channel(channel_id)
+
+        if channel is None:
+            raise ValueError(f"Channel ID {channel_id} not found")
+
         stream.change_device(device_id)
 
         voice = await channel.connect()

--- a/main.pyw
+++ b/main.pyw
@@ -137,6 +137,11 @@ query.add_argument(
 args = parser.parse_args()
 is_gui = not any([args.channel, args.device, args.query, args.online])
 
+# Validate CLI arguments when running in CLI mode
+if (not is_gui and not args.query and not args.online and
+        (args.channel is None or args.device is None)):
+    parser.error("Both --channel and --device are required for CLI mode")
+
 # Setup logging based on verbosity
 logger = setup_logging(args.verbose)
 


### PR DESCRIPTION
## Summary
- prevent running CLI mode without both `--channel` and `--device` arguments
- validate channel id in CLI connect

## Testing
- `python -m py_compile cli.py main.pyw gui.py sound.py`

------
https://chatgpt.com/codex/tasks/task_e_68408736f390832a8b2d61861595b0b6