### PR TITLE
Fix bug and add basic test

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ pip install -r requirements.txt
 
 ```bash
 # Install system dependencies
-sudo apt-get install libportaudio2 libxcb-xinerama0
+sudo apt-get install libportaudio2 libxcb-xinerama0 libopus0
 
 # Install Python dependencies
 pip install -r requirements.txt

--- a/gui.py
+++ b/gui.py
@@ -145,11 +145,11 @@ class Connection:
         except Exception:
             logging.exception("Error on change_device")
 
-    async def change_server(self, deselcted, selected):
+    async def change_server(self, deselected, selected):
         try:
             selection = self.servers.itemData(selected)
 
-            self.parent.exclude(deselcted, selected)
+            self.parent.exclude(deselected, selected)
             self.channels.clear()
             self.channels.addItem("None", None)
 

--- a/sound.py
+++ b/sound.py
@@ -2,7 +2,7 @@ import discord
 import sounddevice as sd
 from pprint import pformat
 
-DEFAULT = 0
+DEFAULT = sd.default.hostapi
 sd.default.channels = 2
 sd.default.dtype = "int16"
 sd.default.latency = "low"

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -1,0 +1,23 @@
+import importlib
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import pytest
+
+
+def test_query_devices_no_devices(monkeypatch):
+    dummy_sd = types.SimpleNamespace(
+        default=types.SimpleNamespace(hostapi=0, channels=None, dtype=None, latency=None, samplerate=None),
+        query_devices=lambda: [],
+        query_hostapis=lambda: []
+    )
+    monkeypatch.setitem(sys.modules, 'sounddevice', dummy_sd)
+    if 'sound' in sys.modules:
+        del sys.modules['sound']
+
+    spec = importlib.util.spec_from_file_location('sound', Path('sound.py'))
+    sound = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(sound)
+    with pytest.raises(sound.DeviceNotFoundError):
+        sound.query_devices()


### PR DESCRIPTION
## Summary
- fix server deselect typo in GUI
- respect current host API when querying devices
- document `libopus0` install on Linux
- add unit test for `query_devices`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840873e343c832a94ad7fa561129dc0